### PR TITLE
Added ArrayProvider

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,6 +1,6 @@
 /**
  * @see       https://github.com/zendframework/zend-config-aggregator for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @copyright Copyright (c) 2015-2016 Mateusz Tymek (http://mateusztymek.pl)
  * @license   https://github.com/zendframework/zend-config-aggregator/blob/master/LICENSE.md New BSD License
  */

--- a/src/ArrayProvider.php
+++ b/src/ArrayProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config-aggregator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Mateusz Tymek (http://mateusztymek.pl)
+ * @license   https://github.com/zendframework/zend-config-aggregator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\ConfigAggregator;
+
+/**
+ * Provider that returns the array seeded to itself.
+ *
+ * Primary use case is configuration cache-related settings.
+ */
+class ArrayProvider
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function __invoke()
+    {
+        return $this->config;
+    }
+}

--- a/test/ArrayProviderTest.php
+++ b/test/ArrayProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-config-aggregator for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2016 Mateusz Tymek (http://mateusztymek.pl)
+ * @license   https://github.com/zendframework/zend-config-aggregator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\ConfigAggregator;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ConfigAggregator\ArrayProvider;
+
+class ArrayProviderTest extends TestCase
+{
+    public function testProviderIsCallable()
+    {
+        $provider = new ArrayProvider([]);
+        $this->assertInternalType('callable', $provider);
+    }
+
+    public function testProviderReturnsArrayProvidedAtConstruction()
+    {
+        $expected = [
+            'foo' => 'bar',
+        ];
+        $provider = new ArrayProvider($expected);
+
+        $this->assertSame($expected, $provider());
+    }
+}


### PR DESCRIPTION
ArrayProvider allows users to define short, targeted configuration arrays within the file that defines the `ConfigAggregator` instance; a specific use case is for configuration cache-related settings.

As an example:

```php
$configCache = ['config_cache_path' => 'data/cache/config.php'];

new ConfigAggregator([
   new ArrayProvider($configCache),
   /* ... */
], $configCache['config_cache_path'])
```

Resolves #1.