### PR TITLE
Added GLOB_NOSORT to glob flags

### DIFF
--- a/src/GlobTrait.php
+++ b/src/GlobTrait.php
@@ -27,9 +27,9 @@ trait GlobTrait
     private function glob($pattern)
     {
         if (class_exists(Glob::class)) {
-            return Glob::glob($pattern, Glob::GLOB_BRACE);
+            return Glob::glob($pattern, Glob::GLOB_BRACE | Glob::GLOB_NOSORT);
         }
 
-        return glob($pattern, GLOB_BRACE);
+        return glob($pattern, GLOB_BRACE | GLOB_NOSORT);
     }
 }

--- a/test/Resources/config/main.global.php
+++ b/test/Resources/config/main.global.php
@@ -2,4 +2,5 @@
 
 return [
     'fruit' => 'banana',
+    'vegetable' => 'carrot'
 ];


### PR DESCRIPTION
The recently released Mac highSierra OS has changed the order globbed files are returned when using `GLOB_BRACE`. Previously (and on any *nix box I've tried) you'd get something like:

```
config.global.php
foo.global.php
config.local.php
```

On highSierra you get:

```
config.global.php
config.local.php
foo.global.php
```

According to the [libc man page](https://www.gnu.org/software/libc/manual/html_node/Calling-Glob.html) `glob` sorts the file names alphabetically. But clearly this doesn't happen in most implementations when using brace patterns. 

This PR adds a `GLOB_NOSORT` flag to ensure files are returned in brace order under highSierra. Note files within each brace match will now be returned in filesystem order: if someone were relying on entries in `b.global.php` overriding `a.global.php` this may not happen.